### PR TITLE
Make HTTPOpener support https

### DIFF
--- a/fs/opener.py
+++ b/fs/opener.py
@@ -655,7 +655,7 @@ example:
         return fs, ''
 
 class HTTPOpener(Opener):
-    names = ['http']
+    names = ['http', 'https']
     desc = """HTTP file opener. HTTP only supports reading files, and not much else.
 
 example:


### PR DESCRIPTION
Instead of:

```python
In [10]: f = fsopen('https://pypi.python.org/packages/source/g/grace/grace-0.4.0.tar.gz#md5=d52a684adf5137a2b00b3f9b353e2c2f', 'rb')
---------------------------------------------------------------------------
NoOpenerError                             Traceback (most recent call last)
<ipython-input-10-a890342598f8> in <module>()
----> 1 f = fsopen('https://pypi.python.org/packages/source/g/grace/grace-0.4.0.tar.gz#md5=d52a684adf5137a2b00b3f9b353e2c2f', 'rb')

/Users/marca/dev/git-repos/pyfilesystem/fs/opener.py in open(self, fs_url, mode, **kwargs)
    270
    271         writeable = 'w' in mode or 'a' in mode or '+' in mode
--> 272         fs, path = self.parse(fs_url, writeable=writeable)
    273         file_object = fs.open(path, mode)
    274

/Users/marca/dev/git-repos/pyfilesystem/fs/opener.py in parse(self, fs_url, default_fs_name, writeable, create_dir, cache_hint)
    229
    230         fs_name,  fs_name_params = _parse_name(fs_name)
--> 231         opener = self.get_opener(fs_name)
    232
    233         if fs_url is None:

/Users/marca/dev/git-repos/pyfilesystem/fs/opener.py in get_opener(self, name)
    176         """
    177         if name not in self.registry:
--> 178             raise NoOpenerError("No opener for %s" % name)
    179         index = self.registry[name]
    180         return self.openers[index]

NoOpenerError: No opener for https
```

we get:

```python
In [1]: from fs.opener import fsopen

In [2]: f = fsopen('https://pypi.python.org/packages/source/g/grace/grace-0.4.0.tar.gz#md5=d52a684adf5137a2b00b3f9b353e2c2f', 'rb')

In [3]: f
Out[3]: <IO wrapper for <fs.filelike.FileWrapper object at 0x104d4b910>>

In [4]: len(f.read())
Out[4]: 26211
```