### PR TITLE
tox.ini: Add py34; remove py3[12]; refactor

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,45 +1,16 @@
 [tox]
-envlist = py26,py27,py31,py32,py33,pypy
+envlist = py26, py27, py33, py34, pypy
 sitepackages = False
 
 [testenv]
-deps = distribute
-	six
-	dexml
-	paramiko
-	boto
-	nose
-	mako
-	pyftpdlib
+deps =
+	  six
+	  dexml
+	  nose
+    py31,py32,py33,py34: winpdb
+	  py26,py27: paramiko
+	  py26,py27: boto
+	  py26,py27: mako
+	  py26,py27: pyftpdlib
 changedir=.tox
-commands = nosetests fs.tests -v \
-	[]
-
-
-[testenv:py31]
-commands = nosetests fs.tests -v \
-    []
-deps = distribute
-    six
-    dexml
-    nose
-    winpdb
-
-[testenv:py32]
-commands = nosetests fs.tests -v \
-	[]
-deps = distribute
-	six
-	dexml
-	nose
-	winpdb
-
-[testenv:py33]
-commands = nosetests fs.tests -v \
-    []
-deps = distribute
-    six
-    dexml
-    nose
-    winpdb
-
+commands = nosetests {posargs:-v fs.tests}


### PR DESCRIPTION
- Added py34
- Removed py31 and py32 because they're old and harder to support
- Refactored duplicate stuff to avoid repetition using new tox features like generative environments