### PR TITLE
order_sensitive property is set to False for all dexml models

### DIFF
--- a/fs/contrib/davfs/xmlobj.py
+++ b/fs/contrib/davfs/xmlobj.py
@@ -26,6 +26,7 @@ class _davbase(dexml.Model):
     class meta:
         namespace = "DAV:"
         namespace_prefix = "D"
+        order_sensitive = False
 
 
 class HrefField(fields.String):


### PR DESCRIPTION
Some WebDAV servers respond with XMLs which do not have the order of tags the same as dexml models have and as a result "dexml.ParseError: required field not found: 'props'" is raised. This commit fixes the issue.