### PR TITLE
u'/' must not be unicode - both because os.sep is a byte string

### DIFF
--- a/fs/osfs/__init__.py
+++ b/fs/osfs/__init__.py
@@ -164,7 +164,7 @@ class OSFS(OSFSXAttrMixin, OSFSWatchMixin, FS):
 
     def getsyspath(self, path, allow_none=False):
         self.validatepath(path)
-        path = relpath(normpath(path)).replace(u"/", os.sep)
+        path = relpath(normpath(path)).replace("/", os.sep)
         path = os.path.join(self.root_path, path)
         if not path.startswith(self.root_path):
             raise PathError(path, msg="OSFS given path outside root: %(path)s")


### PR DESCRIPTION
and not a unicode string and it causes UnicodeErrors with code
using pyfilsystem for transparent access to arbitrary filesystems
using the same code as
www.xml-director.info.