### PR TITLE
Fix ftpfs._encode for python3

### DIFF
--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -834,8 +834,8 @@ def ftperrors(f):
 
 
 def _encode(s):
-    if isinstance(s, unicode):
-        return s.encode('utf-8')
+    if six.PY3:
+        return six.u(s)
     return s
 
 class _DirCache(dict):


### PR DESCRIPTION
This fixes the issue brought up in https://github.com/PyFilesystem/pyfilesystem/issues/181#issuecomment-91821556.  This will fix ftpfs on python3
