### PR TITLE
Fix for long UNC paths using opener.parse

### DIFF
--- a/fs/opener.py
+++ b/fs/opener.py
@@ -85,7 +85,7 @@ class NoOpenerError(OpenerError):
 def _expand_syspath(path):
     if path is None:
         return path
-    if path.startswith('\\\\?\\'):
+    if path.startswith('\\\\?\\') and not path.startswith('\\\\?\\UNC\\'):
         path = path[4:]
     path = os.path.expanduser(os.path.expandvars(path))
     path = os.path.normpath(os.path.abspath(path))


### PR DESCRIPTION
I'm not sure if this is the correct fix, but it's at least a workaround for long UNC paths. This code:

```
uri = r'\\?\UNC\VBOXSVR\work\stuff.xex'
fs, relpath = opener.parse(uri)
print relpath
```
was producing \\?\N:\src\omnivore\UNC\VBOXSVR\work, so it was thinking that the `UNC` part was a parent directory rather than the UNC path specifier.