### PR TITLE
FTPFS: Use a non decoded path in python3

### DIFF
--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -958,7 +958,18 @@ class FTPFS(FS):
 
         def on_line(line):
             if not isinstance(line, unicode):
-                line = line.decode('utf-8')
+                for encoding in ["utf-8", "latin-1"]:
+                    decoded_line = None
+                    try:
+                        decoded_line = line.decode(encoding)
+                    except UnicodeDecodeError:
+                        pass
+                if decoded_line is None:
+                    raise Exception(
+                        "Unable to decode the line {}".format(line)
+                    )
+                line = decoded_line
+
             info = parse_ftp_list_line(line, self.use_mlst)
             if info:
                 info = info.__dict__


### PR DESCRIPTION
In python ftplib uses unicode instead of bytes.
