### PR TITLE
Dokan - GetFileSecurity has a default implementation since 1.0.3

### DIFF
--- a/fs/expose/dokan/__init__.py
+++ b/fs/expose/dokan/__init__.py
@@ -812,17 +812,6 @@ class FSOperations(object):
 
     @handle_fs_errors
     def GetFileSecurity(self, path, securityinformation, securitydescriptor, securitydescriptorlength, neededlength, info):
-        securitydescriptor = ctypes.cast(securitydescriptor, libdokan.PSECURITY_DESCRIPTOR)
-        path = self._dokanpath2pyfs(path)
-        if self.fs.isdir(path):
-            res = libdokan.GetFileSecurity(
-                self.securityfolder,
-                ctypes.cast(securityinformation, libdokan.PSECURITY_INFORMATION)[0],
-                securitydescriptor,
-                securitydescriptorlength,
-                neededlength,
-            )
-            return STATUS_SUCCESS if res else STATUS_BUFFER_OVERFLOW
         return STATUS_NOT_IMPLEMENTED
 
     @handle_fs_errors

--- a/fs/expose/dokan/libdokan.py
+++ b/fs/expose/dokan/libdokan.py
@@ -272,13 +272,3 @@ DokanResetTimeout.argtypes = (
     ULONG,  #timeout
     PDOKAN_FILE_INFO,  # file info pointer
 )
-
-GetFileSecurity = windll.advapi32.GetFileSecurityW
-GetFileSecurity.restype = BOOL
-GetFileSecurity.argtypes = (
-    LPWSTR,                     # _In_ LPCTSTR lpFileName,
-    SECURITY_INFORMATION,       # _In_ SECURITY_INFORMATION RequestedInformation,
-    PSECURITY_DESCRIPTOR,       # _Out_opt_ PSECURITY_DESCRIPTOR pSecurityDescriptor,
-    DWORD,                      # _In_ DWORD nLength,
-    LPDWORD,                    # _Out_ LPDWORD lpnLengthNeeded
-)


### PR DESCRIPTION
Since 1.0.3 Dokan with commit https://github.com/dokan-dev/dokany/commit/548eea55f578c5dcb1f2ed6b69154b1592468b87

The current GetFileSecurity in pyfilesystem is no longer needed
https://github.com/PyFilesystem/pyfilesystem/blob/master/fs/expose/dokan/__init__.py#L814